### PR TITLE
チャンネル一覧の表示を改善

### DIFF
--- a/lua/neo-slack/api.lua
+++ b/lua/neo-slack/api.lua
@@ -226,10 +226,13 @@ function M.get_channels(callback)
   local params = {
     exclude_archived = true,
     types = 'public_channel,private_channel',
-    limit = 1000  -- より多くのチャンネルを取得
+    limit = 1000,  -- より多くのチャンネルを取得
+    include_num_members = true,  -- メンバー数を含める
+    exclude_archived = true
   }
   
-  M.request('GET', 'conversations.list', params, function(success, data)
+  -- users.conversations を使用して、未読カウントを含むチャンネル一覧を取得
+  M.request('GET', 'users.conversations', params, function(success, data)
     if success then
       callback(true, data.channels)
     else
@@ -240,7 +243,7 @@ function M.get_channels(callback)
         -- ユーザートークン（xoxp-）を使用するための情報を追加
         notify('チャンネル一覧の取得に失敗しました - 権限不足 (missing_scope)\n' ..
                'Slackトークンに必要な権限がありません。\n' ..
-               '必要な権限: channels:read, groups:read, im:read, mpim:read\n' ..
+               '必要な権限: channels:read, groups:read, im:read, mpim:read, users:read\n' ..
                'ユーザー自身として送信するには、ボットトークン（xoxb-）ではなく\n' ..
                'ユーザートークン（xoxp-）を使用してください。\n' ..
                '1. https://api.slack.com/apps にアクセス\n' ..

--- a/lua/neo-slack/ui.lua
+++ b/lua/neo-slack/ui.lua
@@ -480,9 +480,8 @@ function M.show_channels(channels)
         local has_unread = channel.unread_count and channel.unread_count > 0
         local unread = has_unread and string.format(' (%d)', channel.unread_count) or ''
         
-        -- 未読があるチャンネルには "unread_" プレフィックスを追加、既読済みには "read_" プレフィックスを追加
-        local read_status = has_unread and "unread_" or "read_"
-        table.insert(lines, string.format('%s %s %s%s%s', read_status, member_status, prefix, channel.name, unread))
+        -- プレフィックスなしでチャンネル情報を表示
+        table.insert(lines, string.format('%s %s%s%s', member_status, prefix, channel.name, unread))
         
         -- チャンネルIDを保存（後で使用）
         vim.api.nvim_buf_set_var(bufnr, 'channel_' .. #lines, channel.id)
@@ -518,9 +517,8 @@ function M.show_channels(channels)
           local has_unread = channel.unread_count and channel.unread_count > 0
           local unread = has_unread and string.format(' (%d)', channel.unread_count) or ''
           
-          -- 未読があるチャンネルには "unread_" プレフィックスを追加、既読済みには "read_" プレフィックスを追加
-          local read_status = has_unread and "unread_" or "read_"
-          table.insert(lines, string.format('%s %s %s %s%s', read_status, member_status, prefix, channel.name, unread))
+          -- プレフィックスなしでチャンネル情報を表示
+          table.insert(lines, string.format('%s %s %s%s', member_status, prefix, channel.name, unread))
           
           -- チャンネルIDを保存（後で使用）
           vim.api.nvim_buf_set_var(bufnr, 'channel_' .. #lines, channel.id)
@@ -545,9 +543,8 @@ function M.show_channels(channels)
       local has_unread = channel.unread_count and channel.unread_count > 0
       local unread = has_unread and string.format(' (%d)', channel.unread_count) or ''
       
-      -- 未読があるチャンネルには "unread_" プレフィックスを追加、既読済みには "read_" プレフィックスを追加
-      local read_status = has_unread and "unread_" or "read_"
-      table.insert(lines, string.format('%s %s %s %s%s', read_status, member_status, prefix, channel.name, unread))
+      -- プレフィックスなしでチャンネル情報を表示
+      table.insert(lines, string.format('%s %s %s%s', member_status, prefix, channel.name, unread))
       
       -- チャンネルIDを保存（後で使用）
       vim.api.nvim_buf_set_var(bufnr, 'channel_' .. #lines, channel.id)
@@ -883,8 +880,6 @@ end
 --- @return nil
 function M.select_channel()
   local line = vim.api.nvim_get_current_line()
-  -- "unread_" または "read_" プレフィックスを削除
-  line = line:gsub("^unread_", ""):gsub("^read_", "")
   local line_nr = vim.api.nvim_win_get_cursor(0)[1]
   local bufnr = vim.api.nvim_get_current_buf()
   

--- a/syntax/neo-slack-channels.vim
+++ b/syntax/neo-slack-channels.vim
@@ -11,14 +11,14 @@ endif
 syntax match neoSlackChannelsHeader /^# .*$/
 
 " チャンネル情報
-syntax match neoSlackChannelPublic /^read_. # .*$\|^. # .*$/
-syntax match neoSlackChannelPrivate /^read_. 🔒 .*$\|^. 🔒 .*$/
-syntax match neoSlackChannelJoined /^read_✓ [#🔒] .*$\|^✓ [#🔒] .*$/
+syntax match neoSlackChannelPublic /^. # .*$/
+syntax match neoSlackChannelPrivate /^. 🔒 .*$/
+syntax match neoSlackChannelJoined /^✓ [#🔒] .*$/
 syntax match neoSlackChannelUnread /([0-9]\+)$/
 
-" 未読/既読状態
-syntax match neoSlackChannelUnreadState /^unread_.*$/
-syntax match neoSlackChannelReadState /^read_.*$/
+" 未読/既読状態 - チャンネル全体で区別
+syntax match neoSlackChannelUnreadState /^. [#🔒] .*([0-9]\+)$/
+syntax match neoSlackChannelReadState /^. [#🔒] .*[^)]$/
 
 " ハイライトの定義
 highlight default link neoSlackChannelsHeader Title


### PR DESCRIPTION
## 修正内容

1. チャンネル一覧から `read_` プレフィックスを削除
   - 既読/未読は色だけで判別できるようになりました
   - プレフィックスを削除することで表示がすっきりしました

2. Slack APIから未読状態を正確に取得するために `users.conversations` を使用
   - Slack App側で「未読あり」となっているチャンネルが正しく表示されるようになりました
   - 以前は全チャンネルが既読として表示されていた問題を修正しました