### PR TITLE
improve: 初期化プロセスの改善 - 非同期初期化と自動再接続機能の導入

### DIFF
--- a/lua/neo-slack/core/config.lua
+++ b/lua/neo-slack/core/config.lua
@@ -16,6 +16,9 @@ M.defaults = {
   refresh_interval = 30,
   notification = true,
   debug = false,
+  auto_reconnect = true,
+  reconnect_interval = 300, -- 5分
+  auto_open_default_channel = true,
   layout = {
     type = 'split',  -- 'split', 'float', 'tab', 'telescope'
     channels = {
@@ -37,6 +40,15 @@ M.defaults = {
     messages = '<leader>sm',
     reply = '<leader>sr',
     react = '<leader>se',
+  },
+  initialization = {
+    async = true,
+    timeout = 30, -- 初期化タイムアウト（秒）
+    retry = {
+      enabled = true,
+      max_attempts = 3,
+      delay = 5, -- 再試行までの遅延（秒）
+    }
   }
 }
 
@@ -88,6 +100,21 @@ function M.load_from_vim_globals()
     M.current.debug = vim.g.neo_slack_debug == 1
   end
   
+  -- 自動再接続
+  if vim.g.neo_slack_auto_reconnect ~= nil then
+    M.current.auto_reconnect = vim.g.neo_slack_auto_reconnect == 1
+  end
+  
+  -- 再接続間隔
+  if vim.g.neo_slack_reconnect_interval then
+    M.current.reconnect_interval = vim.g.neo_slack_reconnect_interval
+  end
+  
+  -- デフォルトチャンネルの自動表示
+  if vim.g.neo_slack_auto_open_default_channel ~= nil then
+    M.current.auto_open_default_channel = vim.g.neo_slack_auto_open_default_channel == 1
+  end
+  
   -- キーマッピング
   if vim.g.neo_slack_keymaps then
     M.current.keymaps = vim.tbl_deep_extend('force', M.current.keymaps, vim.g.neo_slack_keymaps)
@@ -96,6 +123,11 @@ function M.load_from_vim_globals()
   -- レイアウト
   if vim.g.neo_slack_layout then
     M.current.layout = vim.tbl_deep_extend('force', M.current.layout, vim.g.neo_slack_layout)
+  end
+  
+  -- 初期化設定
+  if vim.g.neo_slack_initialization then
+    M.current.initialization = vim.tbl_deep_extend('force', M.current.initialization, vim.g.neo_slack_initialization)
   end
 end
 

--- a/lua/neo-slack/core/initialization.lua
+++ b/lua/neo-slack/core/initialization.lua
@@ -1,0 +1,399 @@
+---@brief [[
+--- neo-slack.nvim 初期化管理モジュール
+--- プラグインの初期化プロセスを管理します
+---@brief ]]
+
+local events = require('neo-slack.core.events')
+local utils = require('neo-slack.utils')
+local config = require('neo-slack.core.config')
+
+---@class NeoSlackInitialization
+---@field status table 初期化ステータス
+---@field steps table 初期化ステップ
+---@field current_step number 現在のステップ
+---@field total_steps number 全ステップ数
+---@field is_initializing boolean 初期化中かどうか
+---@field is_initialized boolean 初期化済みかどうか
+---@field reconnect_timer any 再接続タイマー
+local M = {}
+
+-- 初期化ステータス
+M.status = {
+  core = false,
+  storage = false,
+  token = false,
+  api = false,
+  notification = false,
+  data = false,
+  ui = false,
+  events = false,
+}
+
+-- 初期化ステップ
+M.steps = {
+  { name = 'core', description = 'コアモジュールの初期化' },
+  { name = 'storage', description = 'ストレージの初期化' },
+  { name = 'token', description = 'トークンの取得' },
+  { name = 'api', description = 'APIクライアントの初期化' },
+  { name = 'notification', description = '通知システムの初期化' },
+  { name = 'data', description = 'データの読み込み' },
+  { name = 'ui', description = 'UIの初期化' },
+  { name = 'events', description = 'イベントハンドラの登録' },
+}
+
+-- 初期化状態
+M.current_step = 0
+M.total_steps = #M.steps
+M.is_initializing = false
+M.is_initialized = false
+M.reconnect_timer = nil
+
+-- 通知ヘルパー関数
+---@param message string 通知メッセージ
+---@param level number 通知レベル
+local function notify(message, level)
+  utils.notify(message, level)
+end
+
+-- デバッグログ
+---@param message string ログメッセージ
+local function debug_log(message)
+  if config.is_debug() then
+    notify('初期化: ' .. message, vim.log.levels.DEBUG)
+  end
+end
+
+-- 初期化ステップを開始
+---@param step_name string ステップ名
+---@return boolean 開始に成功したかどうか
+local function start_step(step_name)
+  for i, step in ipairs(M.steps) do
+    if step.name == step_name then
+      M.current_step = i
+      debug_log(string.format('[%d/%d] %s を開始...', i, M.total_steps, step.description))
+      events.emit('initialization:step_started', step_name, i, M.total_steps)
+      return true
+    end
+  end
+  return false
+end
+
+-- 初期化ステップを完了
+---@param step_name string ステップ名
+---@param success boolean 成功したかどうか
+---@param error_message string|nil エラーメッセージ
+local function complete_step(step_name, success, error_message)
+  M.status[step_name] = success
+  
+  if success then
+    debug_log(string.format('[%d/%d] %s が完了しました', M.current_step, M.total_steps, M.steps[M.current_step].description))
+  else
+    local message = string.format('[%d/%d] %s に失敗しました', M.current_step, M.total_steps, M.steps[M.current_step].description)
+    if error_message then
+      message = message .. ': ' .. error_message
+    end
+    notify(message, vim.log.levels.ERROR)
+  end
+  
+  events.emit('initialization:step_completed', step_name, success, error_message)
+  
+  -- 全てのステップが完了したかチェック
+  if M.current_step == M.total_steps then
+    M.is_initializing = false
+    M.is_initialized = true
+    events.emit('initialization:completed', M.status)
+    
+    -- 成功したステップ数をカウント
+    local success_count = 0
+    for _, status in pairs(M.status) do
+      if status then
+        success_count = success_count + 1
+      end
+    end
+    
+    local success_rate = math.floor((success_count / M.total_steps) * 100)
+    notify(string.format('初期化が完了しました (%d%%)', success_rate), vim.log.levels.INFO)
+    
+    -- 自動再接続タイマーを設定
+    M.setup_reconnect_timer()
+  end
+end
+
+-- 非同期で次のステップを実行
+---@param callback function|nil 完了時のコールバック
+local function run_next_step_async(callback)
+  vim.defer_fn(function()
+    M.run_next_step(callback)
+  end, 0)
+end
+
+-- 次のステップを実行
+---@param callback function|nil 完了時のコールバック
+function M.run_next_step(callback)
+  if M.current_step >= M.total_steps then
+    if callback then
+      callback(true)
+    end
+    return
+  end
+  
+  local next_step = M.current_step + 1
+  local step = M.steps[next_step]
+  
+  if not step then
+    if callback then
+      callback(true)
+    end
+    return
+  end
+  
+  start_step(step.name)
+  
+  -- ステップごとの処理
+  if step.name == 'core' then
+    -- コアモジュールの初期化
+    events.emit('core:before_init', config.get())
+    complete_step('core', true)
+    run_next_step_async(callback)
+    
+  elseif step.name == 'storage' then
+    -- ストレージの初期化
+    local storage = require('neo-slack.storage')
+    local success = storage.init()
+    complete_step('storage', success, success and nil or 'ストレージディレクトリの作成に失敗しました')
+    run_next_step_async(callback)
+    
+  elseif step.name == 'token' then
+    -- トークンの取得
+    local token = config.get('token')
+    
+    if token and token ~= '' then
+      complete_step('token', true)
+      run_next_step_async(callback)
+    else
+      -- ストレージからトークンを読み込み
+      local storage = require('neo-slack.storage')
+      local saved_token = storage.load_token()
+      
+      if saved_token then
+        config.set('token', saved_token)
+        notify('保存されたトークンを読み込みました', vim.log.levels.INFO)
+        complete_step('token', true)
+        run_next_step_async(callback)
+      else
+        -- トークンの入力を求める
+        notify('Slackトークンが必要です', vim.log.levels.INFO)
+        
+        -- トークン入力プロンプトを表示
+        vim.ui.input({
+          prompt = 'Slack APIトークンを入力してください: ',
+          default = '',
+          completion = 'file',
+          highlight = function()
+            vim.api.nvim_buf_add_highlight(0, -1, 'Question', 0, 0, -1)
+          end
+        }, function(input)
+          if not input or input == '' then
+            notify('トークンが入力されませんでした。初期化を中断します。', vim.log.levels.WARN)
+            complete_step('token', false, 'トークンが入力されませんでした')
+            if callback then
+              callback(false)
+            end
+            return
+          end
+          
+          -- トークンを設定
+          config.set('token', input)
+          
+          -- トークンを保存
+          if storage.save_token(input) then
+            notify('トークンを保存しました', vim.log.levels.INFO)
+          else
+            notify('トークンの保存に失敗しました', vim.log.levels.ERROR)
+          end
+          
+          complete_step('token', true)
+          run_next_step_async(callback)
+        end)
+      end
+    end
+    
+  elseif step.name == 'api' then
+    -- APIクライアントの初期化
+    local api = require('neo-slack.api')
+    local token = config.get('token')
+    
+    api.setup(token)
+    
+    -- 接続テスト
+    api.test_connection(function(success, data)
+      if success then
+        notify('Slack APIに接続しました - ワークスペース: ' .. (data.team or 'Unknown'), vim.log.levels.INFO)
+        complete_step('api', true)
+      else
+        notify('Slack APIへの接続に失敗しました: ' .. (data.error or 'Unknown error'), vim.log.levels.ERROR)
+        complete_step('api', false, data.error or 'Unknown error')
+      end
+      run_next_step_async(callback)
+    end)
+    
+  elseif step.name == 'notification' then
+    -- 通知システムの初期化
+    if config.get('notification') then
+      local notification = require('neo-slack.notification')
+      notification.setup(config.get('refresh_interval'))
+      complete_step('notification', true)
+    else
+      debug_log('通知システムは無効です')
+      complete_step('notification', true)
+    end
+    run_next_step_async(callback)
+    
+  elseif step.name == 'data' then
+    -- データの読み込み
+    local storage = require('neo-slack.storage')
+    local state = require('neo-slack.state')
+    
+    -- スター付きチャンネルの情報を読み込み
+    local starred_channels = storage.load_starred_channels()
+    state.set_starred_channels(starred_channels)
+    
+    -- カスタムセクションの情報を読み込み
+    local custom_sections = storage.load_custom_sections()
+    state.custom_sections = custom_sections
+    
+    -- チャンネルとセクションの関連付けを読み込み
+    local channel_section_map = storage.load_channel_section_map()
+    state.channel_section_map = channel_section_map
+    
+    -- セクションの折りたたみ状態を初期化
+    state.init_section_collapsed()
+    
+    complete_step('data', true)
+    run_next_step_async(callback)
+    
+  elseif step.name == 'ui' then
+    -- UIの初期化
+    state.set_initialized(true)
+    complete_step('ui', true)
+    run_next_step_async(callback)
+    
+  elseif step.name == 'events' then
+    -- イベントハンドラの登録
+    local neo_slack = require('neo-slack')
+    neo_slack.register_event_handlers()
+    complete_step('events', true)
+    run_next_step_async(callback)
+    
+  else
+    -- 未知のステップ
+    notify('未知の初期化ステップです: ' .. step.name, vim.log.levels.ERROR)
+    complete_step(step.name, false, '未知のステップ')
+    run_next_step_async(callback)
+  end
+end
+
+-- 初期化を開始
+---@param callback function|nil 完了時のコールバック
+function M.start(callback)
+  if M.is_initializing then
+    notify('初期化は既に進行中です', vim.log.levels.WARN)
+    return
+  end
+  
+  if M.is_initialized then
+    notify('既に初期化されています', vim.log.levels.INFO)
+    if callback then
+      callback(true)
+    end
+    return
+  end
+  
+  -- 初期化状態をリセット
+  M.current_step = 0
+  M.is_initializing = true
+  M.is_initialized = false
+  
+  for step_name, _ in pairs(M.status) do
+    M.status[step_name] = false
+  end
+  
+  -- 初期化開始イベントを発行
+  events.emit('initialization:started')
+  
+  notify('初期化を開始します...', vim.log.levels.INFO)
+  
+  -- 最初のステップを実行
+  run_next_step_async(callback)
+end
+
+-- 初期化状態を取得
+---@return table 初期化状態
+function M.get_status()
+  return {
+    status = vim.deepcopy(M.status),
+    current_step = M.current_step,
+    total_steps = M.total_steps,
+    is_initializing = M.is_initializing,
+    is_initialized = M.is_initialized
+  }
+end
+
+-- 自動再接続タイマーを設定
+function M.setup_reconnect_timer()
+  -- 既存のタイマーをクリア
+  if M.reconnect_timer then
+    vim.loop.timer_stop(M.reconnect_timer)
+    M.reconnect_timer = nil
+  end
+  
+  -- 再接続が無効な場合は何もしない
+  if not config.get('auto_reconnect', true) then
+    return
+  end
+  
+  -- 再接続間隔（秒）
+  local interval = config.get('reconnect_interval', 300) -- デフォルト5分
+  
+  -- タイマーを作成
+  M.reconnect_timer = vim.loop.new_timer()
+  
+  -- 定期的に接続をチェック
+  M.reconnect_timer:start(interval * 1000, interval * 1000, vim.schedule_wrap(function()
+    if not M.is_initialized then
+      return
+    end
+    
+    local api = require('neo-slack.api')
+    api.test_connection(function(success, data)
+      if success then
+        debug_log('接続は正常です - ワークスペース: ' .. (data.team or 'Unknown'))
+      else
+        notify('接続が切断されました。再接続を試みます...', vim.log.levels.WARN)
+        
+        -- APIクライアントを再初期化
+        api.setup(config.get('token'))
+        
+        -- 再接続テスト
+        api.test_connection(function(reconnect_success, reconnect_data)
+          if reconnect_success then
+            notify('再接続に成功しました - ワークスペース: ' .. (reconnect_data.team or 'Unknown'), vim.log.levels.INFO)
+            events.emit('reconnected')
+          else
+            notify('再接続に失敗しました: ' .. (reconnect_data.error or 'Unknown error'), vim.log.levels.ERROR)
+          end
+        end)
+      end
+    end)
+  end))
+end
+
+-- 自動再接続タイマーを停止
+function M.stop_reconnect_timer()
+  if M.reconnect_timer then
+    vim.loop.timer_stop(M.reconnect_timer)
+    M.reconnect_timer = nil
+  end
+end
+
+return M

--- a/plugin/neo-slack.vim
+++ b/plugin/neo-slack.vim
@@ -18,12 +18,26 @@ command! -nargs=+ SlackUpload lua require('neo-slack').upload_file(<f-args>)
 command! -nargs=0 SlackDeleteToken lua require('neo-slack').delete_token()
 command! -nargs=? SlackSetToken lua require('neo-slack').prompt_for_token()
 command! -nargs=0 SlackResetToken lua require('neo-slack').reset_token()
+command! -nargs=0 SlackInitStatus lua require('neo-slack').get_initialization_status()
 
 " デフォルト設定
 let g:neo_slack_token = get(g:, 'neo_slack_token', '')
 let g:neo_slack_default_channel = get(g:, 'neo_slack_default_channel', 'general')
 let g:neo_slack_refresh_interval = get(g:, 'neo_slack_refresh_interval', 30)
 let g:neo_slack_notification = get(g:, 'neo_slack_notification', 1)
+let g:neo_slack_debug = get(g:, 'neo_slack_debug', 0)
+let g:neo_slack_auto_reconnect = get(g:, 'neo_slack_auto_reconnect', 1)
+let g:neo_slack_reconnect_interval = get(g:, 'neo_slack_reconnect_interval', 300)
+let g:neo_slack_auto_open_default_channel = get(g:, 'neo_slack_auto_open_default_channel', 1)
+
+" 初期化設定
+let g:neo_slack_initialization = get(g:, 'neo_slack_initialization', {})
+let g:neo_slack_initialization.async = get(g:neo_slack_initialization, 'async', 1)
+let g:neo_slack_initialization.timeout = get(g:neo_slack_initialization, 'timeout', 30)
+let g:neo_slack_initialization.retry = get(g:neo_slack_initialization, 'retry', {})
+let g:neo_slack_initialization.retry.enabled = get(g:neo_slack_initialization.retry, 'enabled', 1)
+let g:neo_slack_initialization.retry.max_attempts = get(g:neo_slack_initialization.retry, 'max_attempts', 3)
+let g:neo_slack_initialization.retry.delay = get(g:neo_slack_initialization.retry, 'delay', 5)
 
 " キーマッピング（ユーザーが設定していない場合のデフォルト）
 if !exists('g:neo_slack_disable_default_mappings') || !g:neo_slack_disable_default_mappings
@@ -31,10 +45,24 @@ if !exists('g:neo_slack_disable_default_mappings') || !g:neo_slack_disable_defau
   nnoremap <silent> <leader>sc :SlackChannels<CR>
   nnoremap <silent> <leader>sm :SlackMessages<CR>
 endif
+
 " プラグインの初期化
 " 自動初期化はデフォルトで無効化（循環参照エラーを避けるため）
 " ユーザーは明示的に :SlackSetup コマンドを実行する必要があります
 
 " 手動初期化用コマンド
 command! -nargs=0 SlackSetup lua require('neo-slack').setup()
-" 自動初期化は VimEnter イベントで行うため、ここでは実行しない
+
+" 自動初期化の設定
+if exists('g:neo_slack_auto_setup') && g:neo_slack_auto_setup
+  augroup neo_slack_auto_setup
+    autocmd!
+    autocmd VimEnter * lua require('neo-slack').setup()
+  augroup END
+endif
+
+" プラグイン終了時の処理
+augroup neo_slack_shutdown
+  autocmd!
+  autocmd VimLeavePre * lua if require('neo-slack').initialization and require('neo-slack').initialization.is_initialized then require('neo-slack').shutdown() end
+augroup END


### PR DESCRIPTION
# 初期化プロセスの改善

neo-slack.nvimプラグインの初期化プロセスを改善するため、以下の機能を導入しました。

## 実装内容

1. **非同期初期化の導入**
   - 初期化プロセスを複数のステップに分割し、非同期で実行
   - 各ステップの成功/失敗を追跡し、エラーが発生しても可能な限り処理を続行
   - 初期化の進行状況を視覚的に表示

2. **自動再接続機能**
   - 接続が切れた場合に自動的に再接続を試みる機能
   - 接続状態を定期的に監視し、必要に応じて再接続

3. **設定オプションの追加**
   - `auto_reconnect`: 自動再接続機能の有効/無効
   - `reconnect_interval`: 再接続間隔（秒）
   - `auto_open_default_channel`: デフォルトチャンネルの自動表示
   - `initialization`: 初期化プロセスの詳細設定

4. **初期化プロセスのログ強化**
   - デバッグモードが有効な場合、初期化プロセスの各ステップを詳細にログ出力
   - 初期化の進行状況を通知

## 改善点

1. **起動時間の短縮**: 時間のかかる処理を非同期に行うことで、プラグインの起動時間を短縮
2. **安定性の向上**: 接続が切れた場合でも自動的に再接続することで、安定性を向上
3. **ユーザー体験の改善**: 初期化の進行状況を視覚的に表示することで、ユーザー体験を向上
4. **カスタマイズ性の向上**: 新しい設定オプションを追加することで、カスタマイズ性を向上
