### PR TITLE
fix: setup_messages_keymaps 関数の構文エラーを修正

### DIFF
--- a/lua/neo-slack/ui.lua
+++ b/lua/neo-slack/ui.lua
@@ -210,7 +210,7 @@ function M.setup_messages_keymaps(bufnr)
   
   -- c: チャンネル一覧に戻る
   vim.api.nvim_buf_set_keymap(bufnr, 'n', 'c', '<cmd>lua require("neo-slack.ui").focus_channels()<CR>', opts)
-}
+end
 
 -- チャンネルを選択またはセクションの折りたたみ/展開
 function M.select_channel_or_toggle_section()


### PR DESCRIPTION
## 問題点

プラグインの読み込み時に以下のエラーが発生していました：

Failed to run config for neo-slack.nvim

vim/loader.lua:0: ...ocal/share/nvim/lazy/neo-slack.nvim/lua/neo-slack/ui.lua:213: unexpected symbol near '}'


これは、`ui.lua` の `setup_messages_keymaps` 関数の終了部分で、Lua の構文に合わない `}` が使用されていたことが原因でした。

## 修正内容

- 213行目の `}` を `end` に置き換え

これにより、プラグインが正常に読み込まれるようになります。