### PR TITLE
Fix: 自動起動時にチャンネル一覧を表示しないように修正

### DIFF
--- a/lua/neo-slack/init.lua
+++ b/lua/neo-slack/init.lua
@@ -48,13 +48,8 @@ function M.setup(opts, callback)
     if success then
       notify('初期化が完了しました', vim.log.levels.INFO)
       
-      -- デフォルトチャンネルを表示
-      if config.get('auto_open_default_channel', true) then
-        local default_channel = config.get('default_channel')
-        if default_channel and default_channel ~= '' then
-          M.list_channels()
-        end
-      end
+      -- 注意: 自動的にチャンネル一覧を表示しないように変更
+      -- チャンネル一覧を表示するには :SlackChannels コマンドを使用してください
     else
       notify('初期化に失敗しました。詳細はログを確認してください。', vim.log.levels.ERROR)
     end


### PR DESCRIPTION
## 概要
neovim初期化時に自動的にneo-slackが起動し、チャンネル一覧が表示される問題を修正しました。この変更により、`:SlackChannels`コマンドを使用して明示的に起動する必要があります。

## 関連Issue
<!-- 関連するIssueがあれば記載してください -->

## 変更内容
- `init.lua`の`M.setup`関数内で、初期化完了時に自動的にチャンネル一覧を表示する部分を削除
- 代わりに、`:SlackChannels`コマンドを使用して明示的に起動するようにコメントを追加

## テスト
- [x] 手動でテストした
  - neovim起動時にneo-slackが自動的に起動しないことを確認
  - `:SlackChannels`コマンドでチャンネル一覧が表示されることを確認

## チェックリスト
- [x] コードスタイルに準拠している（StyLua）
- [x] Luacheckのエラーがない
- [x] ドキュメントを更新した（必要な場合）