### PR TITLE
絵文字リアクションの表示を改善

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,14 @@ Neovimから直接Slackを操作できるプラグインです。このプラグ
 
 - Neovim 0.5.0以上
 - [plenary.nvim](https://github.com/nvim-lua/plenary.nvim)
+- [vim-emoji](https://github.com/junegunn/vim-emoji) (絵文字表示のため)
 - [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim) (オプション、検索機能向上のため)
 
 ### vim-plugを使用する場合
 
 ```vim
 Plug 'nvim-lua/plenary.nvim'
+Plug 'junegunn/vim-emoji'
 Plug 'username/neo-slack.nvim'
 ```
 
@@ -37,7 +39,10 @@ Plug 'username/neo-slack.nvim'
 ```lua
 use {
   'username/neo-slack.nvim',
-  requires = { 'nvim-lua/plenary.nvim' }
+  requires = {
+    'nvim-lua/plenary.nvim',
+    'junegunn/vim-emoji'
+  }
 }
 ```
 
@@ -46,7 +51,10 @@ use {
 ```lua
 {
   'username/neo-slack.nvim',
-  dependencies = { 'nvim-lua/plenary.nvim' },
+  dependencies = {
+    'nvim-lua/plenary.nvim',
+    'junegunn/vim-emoji'
+  },
   config = function()
     -- オプション: 明示的に初期化
     require('neo-slack').setup()

--- a/lua/neo-slack/ui.lua
+++ b/lua/neo-slack/ui.lua
@@ -377,7 +377,7 @@ function M.show_messages(channel, messages)
     if message.reactions and #message.reactions > 0 then
       local reactions = {}
       for _, reaction in ipairs(message.reactions) do
-        table.insert(reactions, string.format(':%s: %d', reaction.name, reaction.count))
+        table.insert(reactions, utils.format_reaction(reaction))
       end
       table.insert(lines, '> ' .. table.concat(reactions, ' '))
     end
@@ -644,7 +644,7 @@ function M.open_thread()
         if reply.reactions and #reply.reactions > 0 then
           local reactions = {}
           for _, reaction in ipairs(reply.reactions) do
-            table.insert(reactions, string.format(':%s: %d', reaction.name, reaction.count))
+            table.insert(reactions, utils.format_reaction(reaction))
           end
           table.insert(lines, '> ' .. table.concat(reactions, ' '))
         end
@@ -721,7 +721,7 @@ function M.show_thread_replies(thread_ts, replies, parent_message)
     if parent_message.reactions and #parent_message.reactions > 0 then
       local reactions = {}
       for _, reaction in ipairs(parent_message.reactions) do
-        table.insert(reactions, string.format(':%s: %d', reaction.name, reaction.count))
+        table.insert(reactions, utils.format_reaction(reaction))
       end
       table.insert(lines, '> ' .. table.concat(reactions, ' '))
     end

--- a/lua/neo-slack/utils.lua
+++ b/lua/neo-slack/utils.lua
@@ -124,4 +124,3 @@ function M.format_reaction(reaction)
 end
 
 return M
-return M

--- a/lua/neo-slack/utils.lua
+++ b/lua/neo-slack/utils.lua
@@ -78,5 +78,50 @@ function M.get_nested(tbl, keys, default)
   end
   return current
 end
+-- 絵文字コードを実際の絵文字に変換
+---@param emoji_code string 絵文字コード（例: ":smile:"）
+---@return string 変換された絵文字または元のコード
+function M.convert_emoji_code(emoji_code)
+  -- vim-emojiプラグインが利用可能かチェック
+  local has_emoji, emoji = pcall(require, 'emoji')
+  if not has_emoji then
+    -- プラグインがない場合は元のコードを返す
+    return emoji_code
+  end
 
+  -- 絵文字コードから名前を抽出（コロンを除去）
+  local emoji_name = emoji_code:match('^:([^:]+):$')
+  if not emoji_name then
+    return emoji_code
+  end
+
+  -- vim-emojiプラグインを使用して変換
+  local emoji_char = emoji.emoji[emoji_name]
+  if emoji_char then
+    return emoji_char
+  end
+
+  -- カスタム絵文字マッピング（vim-emojiにない場合）
+  local custom_emoji = {
+    ["うれしい"] = "😊",
+    ["clap-nya"] = "👏",
+    ["eranyanko"] = "😺",
+    ["nekowaiwai"] = "😻",
+    ["tokiwo_umu_nyanko"] = "🐱"
+    -- 必要に応じて追加
+  }
+
+  return custom_emoji[emoji_name] or emoji_code
+end
+
+-- リアクションを整形（絵文字 + カウント）
+---@param reaction table リアクションオブジェクト
+---@return string 整形されたリアクション文字列
+function M.format_reaction(reaction)
+  local emoji_code = ":" .. reaction.name .. ":"
+  local emoji = M.convert_emoji_code(emoji_code)
+  return emoji .. " " .. reaction.count
+end
+
+return M
 return M


### PR DESCRIPTION
## 概要
Slack App 同様、リアクション（絵文字）が正しく表示されるように修正しました。

## 変更内容
- vim-emojiプラグインを依存関係として追加
- utils.luaに絵文字変換関数を実装
  -  - の形式を実際の絵文字に変換する関数
  -  - リアクションを整形する関数（絵文字 + カウント）
- ui.luaのリアクション表示部分を修正（3箇所）

## 修正前


## 修正後


## 動作確認
- [ ] vim-emojiプラグインがインストールされている環境で、リアクションが正しく表示されることを確認
- [ ] vim-emojiプラグインがインストールされていない環境でも、エラーなく動作することを確認