### PR TITLE
fix: Luaの予約語 'then' をテーブルキーとして使用する際の構文エラーを修正

### DIFF
--- a/lua/neo-slack/utils.lua
+++ b/lua/neo-slack/utils.lua
@@ -422,15 +422,15 @@ end
 M.Promise.__index = M.Promise
 
 -- メソッドを直接テーブルに追加
-M.Promise.then = function(self, ...)
+M.Promise["then"] = function(self, ...)
   return M.Promise.then_func(self, ...)
 end
 
-M.Promise.catch = function(self, ...)
+M.Promise["catch"] = function(self, ...)
   return M.Promise.catch_func(self, ...)
 end
 
-M.Promise.finally = function(self, ...)
+M.Promise["finally"] = function(self, ...)
   return M.Promise.finally_func(self, ...)
 end
 


### PR DESCRIPTION
## 概要

nvim起動時に以下のエラーが発生していました：

config

## 原因

Luaでは  はキーワード（予約語）であり、テーブルのキーとして直接使用することはできません。
 の425行目で  と記述されていましたが、
これがLuaの構文エラーの原因となっていました。

## 修正内容

-  を  に変更
- 同様に  と  も角括弧構文に変更（一貫性のため）

## 影響範囲

この修正により、nvim起動時のエラーが解消され、neo-slack.nvimプラグインが正常に動作するようになります。
APIやその他の機能に影響はありません。