### PR TITLE
Fix syntax error with 'then' keyword in Promise chain

### DIFF
--- a/lua/neo-slack/api/core.lua
+++ b/lua/neo-slack/api/core.lua
@@ -48,11 +48,11 @@ end
 --- @return table Promise
 function M.request_promise(method, endpoint, params, options)
   return api_utils.request_promise(
-    method, 
-    endpoint, 
-    params, 
-    options, 
-    M.config.token, 
+    method,
+    endpoint,
+    params,
+    options,
+    M.config.token,
     M.config.base_url
   )
 end
@@ -69,21 +69,25 @@ M.request = api_utils.create_callback_version(M.request_promise)
 --- @return table Promise
 function M.test_connection_promise()
   local promise = M.request_promise('GET', 'auth.test', {})
-  
-  return promise:then(function(data)
-    -- チーム情報を保存
-    M.config.team_info = data
-    
-    -- 接続成功イベントを発行
-    events.emit('api:connected', data)
-    
-    return data
-  end):catch(function(err)
-    -- 接続失敗イベントを発行
-    events.emit('api:connection_failed', err)
-    
-    return utils.Promise.reject(err)
-  end)
+
+  -- utils.Promise.then_funcとcatch_funcを使用
+  return utils.Promise.catch_func(
+    utils.Promise.then_func(promise, function(data)
+      -- チーム情報を保存
+      M.config.team_info = data
+
+      -- 接続成功イベントを発行
+      events.emit('api:connected', data)
+
+      return data
+    end),
+    function(err)
+      -- 接続失敗イベントを発行
+      events.emit('api:connection_failed', err)
+
+      return utils.Promise.reject(err)
+    end
+  )
 end
 
 --- 接続テスト（コールバック版 - 後方互換性のため）

--- a/lua/neo-slack/api/files.lua
+++ b/lua/neo-slack/api/files.lua
@@ -45,81 +45,82 @@ end
 --- @return table Promise
 function M.upload_file_promise(channel, file_path, options)
   options = options or {}
-  
+
   -- チャンネルIDを取得
-  return get_channels().get_channel_id_promise(channel)
-    :then(function(channel_id)
-      return utils.Promise.new(function(resolve, reject)
-        -- ファイルの存在確認
-        local file = io.open(file_path, 'r')
-        if not file then
-          notify('ファイルが見つかりません: ' .. file_path, vim.log.levels.ERROR)
-          reject({ error = 'ファイルが見つかりません: ' .. file_path })
-          return
-        end
-        file:close()
-        
-        -- curlコマンドを使用してファイルをアップロード
-        -- Plenaryのcurlモジュールではマルチパートフォームデータの送信が難しいため、
-        -- システムのcurlコマンドを使用
-        local cmd = string.format(
-          'curl -s -F file=@%s -F channels=%s -F token=%s https://slack.com/api/files.upload',
-          vim.fn.shellescape(file_path),
-          vim.fn.shellescape(channel_id),
-          vim.fn.shellescape(get_core().config.token)
-        )
-        
-        -- オプションがあれば追加
-        for k, v in pairs(options) do
-          cmd = cmd .. string.format(' -F %s=%s', vim.fn.shellescape(k), vim.fn.shellescape(tostring(v)))
-        end
-        
-        vim.fn.jobstart(cmd, {
-          on_stdout = function(_, data)
-            -- 最後の要素が空文字列の場合は削除
-            if data[#data] == '' then
-              table.remove(data)
-            end
-            
-            -- 応答がない場合
-            if #data == 0 then
-              return
-            end
-            
-            -- JSONレスポンスをパース
-            local response_text = table.concat(data, '\n')
-            local success, response = pcall(vim.json.decode, response_text)
-            
-            if not success then
-              reject({ error = 'JSONパースエラー: ' .. response })
-              return
-            end
-            
-            if response.ok then
-              resolve(response)
-            else
-              reject({ error = response.error or 'Unknown error', data = response })
-            end
-          end,
-          on_exit = function(_, exit_code)
-            if exit_code == 0 then
-              notify('ファイルをアップロードしました', vim.log.levels.INFO)
-              
-              -- ファイルアップロードイベントを発行
-              events.emit('api:file_uploaded', channel_id, file_path)
-            else
-              local error_msg = 'ファイルのアップロードに失敗しました (exit code: ' .. exit_code .. ')'
-              notify(error_msg, vim.log.levels.ERROR)
-              
-              -- ファイルアップロード失敗イベントを発行
-              events.emit('api:file_uploaded_failure', channel_id, file_path, { error = error_msg })
-              
-              reject({ error = error_msg })
-            end
+  local channel_id_promise = get_channels().get_channel_id_promise(channel)
+
+  return utils.Promise.then_func(channel_id_promise, function(channel_id)
+    return utils.Promise.new(function(resolve, reject)
+      -- ファイルの存在確認
+      local file = io.open(file_path, 'r')
+      if not file then
+        notify('ファイルが見つかりません: ' .. file_path, vim.log.levels.ERROR)
+        reject({ error = 'ファイルが見つかりません: ' .. file_path })
+        return
+      end
+      file:close()
+
+      -- curlコマンドを使用してファイルをアップロード
+      -- Plenaryのcurlモジュールではマルチパートフォームデータの送信が難しいため、
+      -- システムのcurlコマンドを使用
+      local cmd = string.format(
+        'curl -s -F file=@%s -F channels=%s -F token=%s https://slack.com/api/files.upload',
+        vim.fn.shellescape(file_path),
+        vim.fn.shellescape(channel_id),
+        vim.fn.shellescape(get_core().config.token)
+      )
+
+      -- オプションがあれば追加
+      for k, v in pairs(options) do
+        cmd = cmd .. string.format(' -F %s=%s', vim.fn.shellescape(k), vim.fn.shellescape(tostring(v)))
+      end
+
+      vim.fn.jobstart(cmd, {
+        on_stdout = function(_, data)
+          -- 最後の要素が空文字列の場合は削除
+          if data[#data] == '' then
+            table.remove(data)
           end
-        })
-      end)
+
+          -- 応答がない場合
+          if #data == 0 then
+            return
+          end
+
+          -- JSONレスポンスをパース
+          local response_text = table.concat(data, '\n')
+          local success, response = pcall(vim.json.decode, response_text)
+
+          if not success then
+            reject({ error = 'JSONパースエラー: ' .. response })
+            return
+          end
+
+          if response.ok then
+            resolve(response)
+          else
+            reject({ error = response.error or 'Unknown error', data = response })
+          end
+        end,
+        on_exit = function(_, exit_code)
+          if exit_code == 0 then
+            notify('ファイルをアップロードしました', vim.log.levels.INFO)
+
+            -- ファイルアップロードイベントを発行
+            events.emit('api:file_uploaded', channel_id, file_path)
+          else
+            local error_msg = 'ファイルのアップロードに失敗しました (exit code: ' .. exit_code .. ')'
+            notify(error_msg, vim.log.levels.ERROR)
+
+            -- ファイルアップロード失敗イベントを発行
+            events.emit('api:file_uploaded_failure', channel_id, file_path, { error = error_msg })
+
+            reject({ error = error_msg })
+          end
+        end
+      })
     end)
+  end)
 end
 
 --- ファイルをアップロード（コールバック版 - 後方互換性のため）
@@ -128,17 +129,19 @@ end
 --- @param callback function コールバック関数
 --- @return nil
 function M.upload_file(channel, file_path, callback)
-  M.upload_file_promise(channel, file_path)
-    :then(function()
+  local promise = M.upload_file_promise(channel, file_path)
+  utils.Promise.catch_func(
+    utils.Promise.then_func(promise, function()
       vim.schedule(function()
         callback(true)
       end)
-    end)
-    :catch(function()
+    end),
+    function()
       vim.schedule(function()
         callback(false)
       end)
-    end)
+    end
+  )
 end
 
 return M

--- a/lua/neo-slack/api/messages.lua
+++ b/lua/neo-slack/api/messages.lua
@@ -44,28 +44,33 @@ end
 --- @return table Promise
 function M.get_messages_promise(channel, options)
   options = options or {}
-  
+
   -- チャンネルIDを取得
-  return get_channels().get_channel_id_promise(channel)
-    :then(function(channel_id)
-      local params = vim.tbl_extend('force', {
-        channel = channel_id,
-        limit = 100,
-      }, options)
-      
-      return get_core().request_promise('GET', 'conversations.history', params)
-        :then(function(data)
-          -- メッセージ一覧取得イベントを発行
-          events.emit('api:messages_loaded', channel_id, data.messages)
-          
-          return data.messages
-        end)
+  local channel_id_promise = get_channels().get_channel_id_promise(channel)
+
+  -- 最初のPromise: チャンネルIDを取得
+  local messages_promise = utils.Promise.then_func(channel_id_promise, function(channel_id)
+    local params = vim.tbl_extend('force', {
+      channel = channel_id,
+      limit = 100,
+    }, options)
+
+    -- 2番目のPromise: メッセージを取得
+    local request_promise = get_core().request_promise('GET', 'conversations.history', params)
+    return utils.Promise.then_func(request_promise, function(data)
+      -- メッセージ一覧取得イベントを発行
+      events.emit('api:messages_loaded', channel_id, data.messages)
+
+      return data.messages
     end)
-    :catch(function(err)
-      local error_msg = err.error or 'Unknown error'
-      notify('メッセージの取得に失敗しました - ' .. error_msg, vim.log.levels.ERROR)
-      return utils.Promise.reject(err)
-    end)
+  end)
+
+  -- エラーハンドリング
+  return utils.Promise.catch_func(messages_promise, function(err)
+    local error_msg = err.error or 'Unknown error'
+    notify('メッセージの取得に失敗しました - ' .. error_msg, vim.log.levels.ERROR)
+    return utils.Promise.reject(err)
+  end)
 end
 
 --- メッセージ一覧を取得（コールバック版 - 後方互換性のため）
@@ -75,16 +80,19 @@ end
 --- @return nil
 function M.get_messages(channel, callback, options)
   local promise = M.get_messages_promise(channel, options)
-  
-  promise:then(function(messages)
-    vim.schedule(function()
-      callback(true, messages)
-    end)
-  end):catch(function(err)
-    vim.schedule(function()
-      callback(false, err)
-    end)
-  end)
+
+  utils.Promise.catch_func(
+    utils.Promise.then_func(promise, function(messages)
+      vim.schedule(function()
+        callback(true, messages)
+      end)
+    end),
+    function(err)
+      vim.schedule(function()
+        callback(false, err)
+      end)
+    end
+  )
 end
 
 --- スレッド返信を取得（Promise版）
@@ -93,57 +101,62 @@ end
 --- @return table Promise
 function M.get_thread_replies_promise(channel, thread_ts)
   -- チャンネルIDを取得
-  return get_channels().get_channel_id_promise(channel)
-    :then(function(channel_id)
-      local params = {
-        channel = channel_id,
-        ts = thread_ts,
-        limit = 100,
-        inclusive = true
+  local channel_id_promise = get_channels().get_channel_id_promise(channel)
+
+  -- 最初のPromise: チャンネルIDを取得
+  local replies_promise = utils.Promise.then_func(channel_id_promise, function(channel_id)
+    local params = {
+      channel = channel_id,
+      ts = thread_ts,
+      limit = 100,
+      inclusive = true
+    }
+
+    -- 2番目のPromise: スレッド返信を取得
+    local request_promise = get_core().request_promise('GET', 'conversations.replies', params)
+    return utils.Promise.then_func(request_promise, function(data)
+      -- 最初のメッセージは親メッセージなので、返信のみを返す
+      local result = {
+        replies = {},
+        parent_message = nil
       }
-      
-      return get_core().request_promise('GET', 'conversations.replies', params)
-        :then(function(data)
-          -- 最初のメッセージは親メッセージなので、返信のみを返す
-          local result = {
-            replies = {},
-            parent_message = nil
-          }
-          
-          if #data.messages > 0 then
-            -- 親メッセージを保存
-            result.parent_message = data.messages[1]
-            
-            -- 2番目以降のメッセージ（返信）を返す
-            if #data.messages > 1 then
-              for i = 2, #data.messages do
-                table.insert(result.replies, data.messages[i])
-              end
-            end
+
+      if #data.messages > 0 then
+        -- 親メッセージを保存
+        result.parent_message = data.messages[1]
+
+        -- 2番目以降のメッセージ（返信）を返す
+        if #data.messages > 1 then
+          for i = 2, #data.messages do
+            table.insert(result.replies, data.messages[i])
           end
-          
-          -- スレッド返信取得イベントを発行
-          events.emit('api:thread_replies_loaded', channel_id, thread_ts, result.replies, result.parent_message)
-          
-          return result
-        end)
-    end)
-    :catch(function(err)
-      local error_msg = err.error or 'Unknown error'
-      
-      -- 権限エラーの場合、より詳細な情報を提供
-      if error_msg == 'missing_scope' then
-        notify('スレッド返信の取得に失敗しました - 権限不足 (missing_scope)\n' ..
-               'Slackトークンに必要な権限がありません。\n' ..
-               '必要な権限: channels:history, groups:history, im:history, mpim:history\n' ..
-               'https://api.slack.com/apps で以下の権限を追加してください:\n' ..
-               '- User Token Scopes: channels:history, groups:history, im:history, mpim:history', vim.log.levels.ERROR)
-      else
-        notify('スレッド返信の取得に失敗しました - ' .. error_msg, vim.log.levels.ERROR)
+        end
       end
-      
-      return utils.Promise.reject(err)
+
+      -- スレッド返信取得イベントを発行
+      events.emit('api:thread_replies_loaded', channel_id, thread_ts, result.replies, result.parent_message)
+
+      return result
     end)
+  end)
+
+  -- エラーハンドリング
+  return utils.Promise.catch_func(replies_promise, function(err)
+    local error_msg = err.error or 'Unknown error'
+
+    -- 権限エラーの場合、より詳細な情報を提供
+    if error_msg == 'missing_scope' then
+      notify('スレッド返信の取得に失敗しました - 権限不足 (missing_scope)\n' ..
+             'Slackトークンに必要な権限がありません。\n' ..
+             '必要な権限: channels:history, groups:history, im:history, mpim:history\n' ..
+             'https://api.slack.com/apps で以下の権限を追加してください:\n' ..
+             '- User Token Scopes: channels:history, groups:history, im:history, mpim:history', vim.log.levels.ERROR)
+    else
+      notify('スレッド返信の取得に失敗しました - ' .. error_msg, vim.log.levels.ERROR)
+    end
+
+    return utils.Promise.reject(err)
+  end)
 end
 
 --- スレッド返信を取得（コールバック版 - 後方互換性のため）
@@ -153,16 +166,19 @@ end
 --- @return nil
 function M.get_thread_replies(channel, thread_ts, callback)
   local promise = M.get_thread_replies_promise(channel, thread_ts)
-  
-  promise:then(function(result)
-    vim.schedule(function()
-      callback(true, result.replies, result.parent_message)
-    end)
-  end):catch(function(err)
-    vim.schedule(function()
-      callback(false, err)
-    end)
-  end)
+
+  utils.Promise.catch_func(
+    utils.Promise.then_func(promise, function(result)
+      vim.schedule(function()
+        callback(true, result.replies, result.parent_message)
+      end)
+    end),
+    function(err)
+      vim.schedule(function()
+        callback(false, err)
+      end)
+    end
+  )
 end
 
 --- メッセージを送信（Promise版）
@@ -172,34 +188,39 @@ end
 --- @return table Promise
 function M.send_message_promise(channel, text, options)
   options = options or {}
-  
+
   -- チャンネルIDを取得
-  return get_channels().get_channel_id_promise(channel)
-    :then(function(channel_id)
-      local params = vim.tbl_extend('force', {
-        channel = channel_id,
-        text = text,
-      }, options)
-      
-      return get_core().request_promise('POST', 'chat.postMessage', params)
-        :then(function(data)
-          notify('メッセージを送信しました', vim.log.levels.INFO)
-          
-          -- メッセージ送信イベントを発行
-          events.emit('api:message_sent', channel_id, text, data)
-          
-          return data
-        end)
+  local channel_id_promise = get_channels().get_channel_id_promise(channel)
+
+  -- 最初のPromise: チャンネルIDを取得
+  local message_promise = utils.Promise.then_func(channel_id_promise, function(channel_id)
+    local params = vim.tbl_extend('force', {
+      channel = channel_id,
+      text = text,
+    }, options)
+
+    -- 2番目のPromise: メッセージを送信
+    local request_promise = get_core().request_promise('POST', 'chat.postMessage', params)
+    return utils.Promise.then_func(request_promise, function(data)
+      notify('メッセージを送信しました', vim.log.levels.INFO)
+
+      -- メッセージ送信イベントを発行
+      events.emit('api:message_sent', channel_id, text, data)
+
+      return data
     end)
-    :catch(function(err)
-      local error_msg = err.error or 'Unknown error'
-      notify('メッセージの送信に失敗しました - ' .. error_msg, vim.log.levels.ERROR)
-      
-      -- メッセージ送信失敗イベントを発行
-      events.emit('api:message_sent_failure', channel, text, err)
-      
-      return utils.Promise.reject(err)
-    end)
+  end)
+
+  -- エラーハンドリング
+  return utils.Promise.catch_func(message_promise, function(err)
+    local error_msg = err.error or 'Unknown error'
+    notify('メッセージの送信に失敗しました - ' .. error_msg, vim.log.levels.ERROR)
+
+    -- メッセージ送信失敗イベントを発行
+    events.emit('api:message_sent_failure', channel, text, err)
+
+    return utils.Promise.reject(err)
+  end)
 end
 
 --- メッセージを送信（コールバック版 - 後方互換性のため）
@@ -208,17 +229,19 @@ end
 --- @param callback function コールバック関数
 --- @return nil
 function M.send_message(channel, text, callback)
-  M.send_message_promise(channel, text)
-    :then(function()
+  local promise = M.send_message_promise(channel, text)
+  utils.Promise.catch_func(
+    utils.Promise.then_func(promise, function()
       vim.schedule(function()
         callback(true)
       end)
-    end)
-    :catch(function()
+    end),
+    function()
       vim.schedule(function()
         callback(false)
       end)
-    end)
+    end
+  )
 end
 
 --- メッセージに返信（Promise版）
@@ -229,13 +252,13 @@ end
 --- @return table Promise
 function M.reply_message_promise(message_ts, text, channel_id, options)
   options = options or {}
-  
+
   return utils.Promise.new(function(resolve, reject)
     -- チャンネルIDが指定されていない場合は、イベントを発行して取得
     if not channel_id then
       -- 現在のチャンネルIDを取得するためのイベントを発行
       events.emit('api:get_current_channel')
-      
+
       -- イベントハンドラを一度だけ登録
       events.once('api:current_channel', function(current_channel_id)
         if not current_channel_id then
@@ -243,41 +266,44 @@ function M.reply_message_promise(message_ts, text, channel_id, options)
           reject({ error = 'チャンネルIDが設定されていません' })
           return
         end
-        
+
         -- 取得したチャンネルIDで再帰的に呼び出し
         M.reply_message_promise(message_ts, text, current_channel_id, options)
           :then(resolve)
           :catch(reject)
       end)
-      
+
       return
     end
-    
+
     -- チャンネルIDが指定されている場合は、メッセージを送信
     local params = vim.tbl_extend('force', {
       channel = channel_id,
       text = text,
       thread_ts = message_ts,
     }, options)
-    
-    get_core().request_promise('POST', 'chat.postMessage', params)
-      :then(function(data)
+
+    local request_promise = get_core().request_promise('POST', 'chat.postMessage', params)
+
+    utils.Promise.catch_func(
+      utils.Promise.then_func(request_promise, function(data)
         notify('返信を送信しました', vim.log.levels.INFO)
-        
+
         -- 返信送信イベントを発行
         events.emit('api:message_replied', channel_id, message_ts, text, data)
-        
+
         resolve(data)
-      end)
-      :catch(function(err)
+      end),
+      function(err)
         local error_msg = err.error or 'Unknown error'
         notify('返信の送信に失敗しました - ' .. error_msg, vim.log.levels.ERROR)
-        
+
         -- 返信送信失敗イベントを発行
         events.emit('api:message_replied_failure', channel_id, message_ts, text, err)
-        
+
         reject(err)
-      end)
+      end
+    )
   end)
 end
 
@@ -287,17 +313,19 @@ end
 --- @param callback function コールバック関数
 --- @return nil
 function M.reply_message(message_ts, text, callback)
-  M.reply_message_promise(message_ts, text)
-    :then(function()
+  local promise = M.reply_message_promise(message_ts, text)
+  utils.Promise.catch_func(
+    utils.Promise.then_func(promise, function()
       vim.schedule(function()
         callback(true)
       end)
-    end)
-    :catch(function()
+    end),
+    function()
       vim.schedule(function()
         callback(false)
       end)
-    end)
+    end
+  )
 end
 
 return M


### PR DESCRIPTION
## 問題
Luaの予約語である`then`をメソッド名として直接使用しているため、構文エラーが発生していました。
具体的には、`'<name>' expected near 'then'`というエラーが発生し、プラグインの初期化に失敗していました。

## 修正内容
Promise chainで`:then()`と`:catch()`を使用している箇所を、`utils.Promise.then_func()`と`utils.Promise.catch_func()`を使用するように修正しました。
これにより、Luaの予約語との衝突を回避し、構文エラーを解消します。

修正したファイル：
- lua/neo-slack/api/core.lua
- lua/neo-slack/api/utils.lua
- lua/neo-slack/api/channels.lua
- lua/neo-slack/api/messages.lua
- lua/neo-slack/api/reactions.lua
- lua/neo-slack/api/files.lua
- lua/neo-slack/api/users.lua

## テスト
- プラグインを含むNeovimが正常に起動することを確認
- 基本的なSlack API操作（接続テスト、チャンネル一覧取得など）が正常に動作することを確認