### PR TITLE
Fix: Luaの予約語thenをメソッド名として使用していた構文エラーを修正

### DIFF
--- a/lua/neo-slack/api/messages.lua
+++ b/lua/neo-slack/api/messages.lua
@@ -269,7 +269,10 @@ function M.reply_message_promise(message_ts, text, channel_id, options)
 
         -- 取得したチャンネルIDで再帰的に呼び出し
         local promise = M.reply_message_promise(message_ts, text, current_channel_id, options)
-        promise:then(resolve):catch(reject)
+        utils.Promise.catch_func(
+          utils.Promise.then_func(promise, resolve),
+          reject
+        )
       end)
 
       return


### PR DESCRIPTION
## 問題点

neovimを起動すると以下のエラーが発生していました：
```
Failed to run config for neo-slack.nvim vim/loader.lua:0: .../nvim/lazy/neo-slack.nvim/lua/neo-slack/api/messages.lua:272: '' expected near 'then'
```

## 原因

`lua/neo-slack/api/messages.lua`の272行目で、Luaの予約語である`then`をメソッド名として直接使用していたことが原因でした。

```lua
promise:then(resolve):catch(reject)
修正内容
予約語を直接使用する代わりに、プロジェクトで定義されているヘルパー関数を使用するように修正しました：

utils.Promise.catch_func(
  utils.Promise.then_func(promise, resolve),
  reject
)
```
この修正により、Luaの構文エラーが解消されます。