### PR TITLE
Fix: UIモジュールがテーブルを返すように修正

### DIFF
--- a/lua/neo-slack/ui.lua
+++ b/lua/neo-slack/ui.lua
@@ -678,3 +678,5 @@ function M.show_messages(channel, messages)
   -- 行とメッセージのマッピングを保存
   M.layout.line_to_message = line_to_message
 end
+
+return M


### PR DESCRIPTION
## 問題点

`:SlackChannels`を実行すると以下のエラーが発生していました：
Error executing vim.schedule lua callback: ...al/share/nvim/lazy/neo-slack.nvim/lua/neo-slack/init.lua:246: attempt to index upvalue 'ui' (a boolean value)


## 原因

`lua/neo-slack/ui.lua`ファイルの最後に`return M`が欠けていたため、モジュールがテーブルを返していませんでした。そのため、`init.lua`で`ui`変数がブール値として扱われ、`ui.show_channels(channels)`でエラーが発生していました。

## 修正内容

`ui.lua`ファイルの最後に`return M`を追加し、モジュールが正しくテーブルを返すようにしました。これにより、`ui.show_channels(channels)`が正常に動作するようになります。