### PR TITLE
Fix SlackChannels command to initialize UI when channel buffer is invalid

### DIFF
--- a/lua/neo-slack/init.lua
+++ b/lua/neo-slack/init.lua
@@ -257,6 +257,16 @@ end
 --- @return nil
 function M.list_channels()
   notify('SlackChannelsコマンドが実行されました', vim.log.levels.INFO)
+
+  -- UIが初期化されているか確認
+  if not ui.layout.channels_buf or not vim.api.nvim_buf_is_valid(ui.layout.channels_buf) then
+    notify('UIを初期化します', vim.log.levels.INFO)
+    -- UIを初期化
+    ui.show()
+    -- UIの初期化中にチャンネル一覧を取得するので、ここでは終了
+    return
+  end
+
   api.get_channels(function(success, channels)
     if success then
       notify('チャンネル一覧の取得に成功しました: ' .. #channels .. '件', vim.log.levels.INFO)


### PR DESCRIPTION
## 問題

コマンドを実行すると、`UI: チャンネルバッファが無効です`というアラートが表示され、チャンネル一覧が表示されませんでした。

## 原因

コマンド実行時にチャンネルバッファが初期化されていないことが原因でした。`ui.show_channels()`関数がチャンネルバッファの有効性をチェックし、バッファが初期化されていないか無効な場合にエラーメッセージを表示していました。

## 修正内容

`init.lua`の`M.list_channels()`関数にUIの初期化チェックを追加し、バッファが存在しない場合は先に`ui.show()`を呼び出してUIを初期化するようにしました。

これにより、`:SlackChannels`コマンドを実行すると、UIが自動的に初期化され、チャンネル一覧が正常に表示されるようになります。