### PR TITLE
Fix syntax error in utils.lua

### DIFF
--- a/lua/neo-slack/api/utils.lua
+++ b/lua/neo-slack/api/utils.lua
@@ -105,7 +105,7 @@ function M.request_promise(method, endpoint, params, options, token, base_url)
           M.notify('JSONパースエラー: ' .. data, vim.log.levels.ERROR)
           reject({ error = 'JSON parse error: ' .. data })
           return
-        }
+        end
 
         if not data.ok then
           M.notify('APIエラー: ' .. (data.error or 'Unknown API error'), vim.log.levels.ERROR)


### PR DESCRIPTION
## 問題

Neovim起動時に以下のエラーが発生していました：

Failed to run config for neo-slack.nvim vim/loader.lua:0: ...are/nvim/lazy/neo-slack.nvim/lua/neo-slack/api/utils.lua:108: unexpected symbol near '}'


## 原因

`lua/neo-slack/api/utils.lua`の108行目に構文エラーがありました。`if`ブロックの終了に`end`ではなく`}`を使用していたことが原因です。

## 修正内容

`if not success then`ブロックの終了に使用されていた閉じ中括弧`}`を正しい終了構文である`end`に置き換えました。

Luaでは条件ブロックは`end`キーワードで終了する必要があります。この修正により、Neovim起動時のエラーが解消されます。