### PR TITLE
CIの改善: 構文エラーを検出するように設定を修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,8 @@ jobs:
         run: luarocks install luacheck
       - name: Run luacheck
         run: |
-          # 警告とエラーがあっても成功するように設定
-          # 特に、E011エラー（expected identifier near 'then'）を無視
-          luacheck lua/ --codes --ignore E011 || [ $? -eq 1 -o $? -eq 2 ]
+          # 構文エラーを検出するために、エラーが発生した場合はCIを失敗させる
+          luacheck lua/ --codes
 
   stylua:
     name: StyLua
@@ -39,7 +38,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           version: latest
           args: --check lua/
-        continue-on-error: true  # エラーがあっても続行する
+        # エラーが発生した場合はCIを失敗させる
 
   tests:
     name: Tests

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -31,7 +31,7 @@ exclude_files = {
 ignore = {
   "212", -- 未使用の引数
   "213", -- 未使用の変数
-  "E011", -- expected identifier near 'then'（Promise構文のため）
+  -- "E011" は削除 - 構文エラーを検出するために無視しない
 }
 
 -- 最大行長
@@ -43,9 +43,7 @@ max_string_line_length = 120
 -- 最大コメント行長
 max_comment_line_length = 120
 
--- 構文エラーを無視する設定
+-- 特定のファイルに対する設定
 files = {
-  ["lua/neo-slack/api.lua"] = {
-    ignore = { "E011" } -- expected identifier near 'then'
-  }
+  -- 構文エラーを無視する設定は削除
 }

--- a/lua/neo-slack/api/utils.lua
+++ b/lua/neo-slack/api/utils.lua
@@ -111,7 +111,7 @@ function M.request_promise(method, endpoint, params, options, token, base_url)
           M.notify('APIエラー: ' .. (data.error or 'Unknown API error'), vim.log.levels.ERROR)
           reject({ error = data.error or 'Unknown API error', data = data })
           return
-        }
+        end
 
         M.notify('APIリクエスト成功: ' .. endpoint, vim.log.levels.INFO)
         resolve(data)

--- a/test/neo-slack_spec.lua
+++ b/test/neo-slack_spec.lua
@@ -8,168 +8,187 @@ describe('neo-slack.nvim', function()
   local api_mock
   local ui_mock
   local notification_mock
-  
+
   before_each(function()
     -- モジュールのモックを作成
     api_mock = mock(require('neo-slack.api'), true)
     ui_mock = mock(require('neo-slack.ui'), true)
     notification_mock = mock(require('neo-slack.notification'), true)
-    
+
     -- テスト対象のモジュールを再読み込み
     package.loaded['neo-slack'] = nil
     neo_slack = require('neo-slack')
   end)
-  
+
   after_each(function()
     -- モックをリセット
     mock.revert(api_mock)
     mock.revert(ui_mock)
     mock.revert(notification_mock)
   end)
-  
+
   describe('setup', function()
     it('should initialize with default config when no options provided', function()
       neo_slack.setup()
-      
+
       assert.are.same('', neo_slack.config.token)
       assert.are.same('general', neo_slack.config.default_channel)
       assert.are.same(30, neo_slack.config.refresh_interval)
       assert.is_true(neo_slack.config.notification)
     end)
-    
+
     it('should merge provided options with defaults', function()
       neo_slack.setup({
         token = 'test-token',
         default_channel = 'random',
       })
-      
+
       assert.are.same('test-token', neo_slack.config.token)
       assert.are.same('random', neo_slack.config.default_channel)
       assert.are.same(30, neo_slack.config.refresh_interval)
       assert.is_true(neo_slack.config.notification)
     end)
-    
+
     it('should initialize API client with token', function()
       neo_slack.setup({
         token = 'test-token',
       })
-      
+
       assert.stub(api_mock.setup).was_called_with('test-token')
     end)
-    
+
     it('should initialize notification system when enabled', function()
       neo_slack.setup({
         token = 'test-token',
         notification = true,
         refresh_interval = 60,
       })
-      
+
       assert.stub(notification_mock.setup).was_called_with(60)
     end)
-    
+
     it('should not initialize notification system when disabled', function()
       neo_slack.setup({
         token = 'test-token',
         notification = false,
       })
-      
+
       assert.stub(notification_mock.setup).was_not_called()
     end)
   end)
-  
+
   describe('status', function()
     it('should call API test_connection', function()
       neo_slack.status()
-      
+
       assert.stub(api_mock.test_connection).was_called()
     end)
   end)
-  
+
   describe('list_channels', function()
     it('should call API get_channels and UI show_channels on success', function()
       -- APIの成功レスポンスをシミュレート
       api_mock.get_channels.invokes(function(callback)
         callback(true, {'channel1', 'channel2'})
       end)
-      
+
       neo_slack.list_channels()
-      
+
       assert.stub(api_mock.get_channels).was_called()
       assert.stub(ui_mock.show_channels).was_called_with({'channel1', 'channel2'})
     end)
-    
+
     it('should not call UI show_channels on API failure', function()
       -- APIの失敗レスポンスをシミュレート
       api_mock.get_channels.invokes(function(callback)
         callback(false, {error = 'API error'})
       end)
-      
+
       neo_slack.list_channels()
-      
+
       assert.stub(api_mock.get_channels).was_called()
       assert.stub(ui_mock.show_channels).was_not_called()
     end)
   end)
-  
+
   describe('list_messages', function()
     it('should use default channel when none provided', function()
       neo_slack.config.default_channel = 'general'
-      
+
       neo_slack.list_messages()
-      
+
       assert.stub(api_mock.get_messages).was_called_with('general', match._)
     end)
-    
+
     it('should use provided channel', function()
       neo_slack.list_messages('random')
-      
+
       assert.stub(api_mock.get_messages).was_called_with('random', match._)
     end)
-    
+
     it('should call UI show_messages on success', function()
       -- APIの成功レスポンスをシミュレート
       api_mock.get_messages.invokes(function(channel, callback)
         callback(true, {'message1', 'message2'})
       end)
-      
+
       neo_slack.list_messages('random')
-      
+
       assert.stub(ui_mock.show_messages).was_called_with('random', {'message1', 'message2'})
     end)
   end)
-  
+
   describe('send_message', function()
     it('should call API send_message with channel and message', function()
       api_mock.send_message.invokes(function(channel, message, callback)
         callback(true)
       end)
-      
+
       neo_slack.send_message('random', 'Hello, world!')
-      
+
       assert.stub(api_mock.send_message).was_called_with('random', 'Hello, world!', match._)
     end)
-    
+
     it('should use default channel when none provided', function()
       neo_slack.config.default_channel = 'general'
       api_mock.send_message.invokes(function(channel, message, callback)
         callback(true)
       end)
-      
+
       neo_slack.send_message(nil, 'Hello, world!')
-      
+
       assert.stub(api_mock.send_message).was_called_with('general', 'Hello, world!', match._)
     end)
-    
+
     it('should concatenate multiple message arguments', function()
       api_mock.send_message.invokes(function(channel, message, callback)
         callback(true)
       end)
-      
+
       neo_slack.send_message('random', 'Hello,', 'world!')
-      
+
       assert.stub(api_mock.send_message).was_called_with('random', 'Hello, world!', match._)
     end)
   end)
-  
+
   -- 他のメソッドのテストも同様に追加
+
+  -- 構文チェックのテスト
+  describe('syntax check', function()
+    it('should have valid syntax in all lua files', function()
+      local function check_file(file)
+        local success, err = loadfile(file)
+        assert.is_not_nil(success, "Syntax error in " .. file .. ": " .. (err or ""))
+      end
+
+      -- すべてのLuaファイルをチェック
+      local handle = io.popen('find lua/ -name "*.lua"')
+      local result = handle:read('*a')
+      handle:close()
+
+      for file in result:gmatch('[^\r\n]+') do
+        check_file(file)
+      end
+    end)
+  end)
 end)


### PR DESCRIPTION
## 問題

Neovim起動時に構文エラーが発生していましたが、CIプロセスでこのエラーが検出されていませんでした。

## 原因

1. CI設定の問題:
   - luacheckがエラーを検出しても、CI設定でエラーを無視するように設定されていた
   - StyLuaもエラーがあっても続行するように設定されていた

2. .luacheckrcの問題:
   - 特定のエラーを無視する設定があった

3. テストの問題:
   - 構文チェックを行うテストがなかった

## 修正内容

1. CI設定の修正:
   - luacheckでエラーが発生した場合はCIを失敗させるように設定を変更
   - StyLuaでエラーが発生した場合もCIを失敗させるように設定を変更

2. .luacheckrcの修正:
   - 構文エラーを無視する設定を削除

3. テストの強化:
   - 全てのLuaファイルの構文チェックを行うテストを追加

4. 既存の構文エラーの修正:
   - `lua/neo-slack/api/utils.lua`の構文エラーを修正（`}`を`end`に置き換え）

これらの修正により、今後同様の構文エラーがCIプロセスで検出されるようになります。