### PR TITLE
メッセージ一覧画面からスレッド表示機能が動作しない問題を修正

### DIFF
--- a/lua/neo-slack/init.lua
+++ b/lua/neo-slack/init.lua
@@ -144,6 +144,9 @@ function M.register_event_handlers()
       M.list_messages(channel_id)
     end
   end)
+
+  -- UIのイベントハンドラを登録
+  get_ui().setup_event_handlers()
 end
 
 --- Slackの接続状態を表示
@@ -468,7 +471,7 @@ function M.list_thread_replies(thread_ts)
       get_state().set_thread_messages(thread_ts, replies)
 
       -- UIにスレッド返信を表示
-      get_ui().show_thread_replies(thread_ts, replies, parent_message)
+      get_ui().show_thread(channel_id, thread_ts, replies, parent_message)
     else
       notify('スレッド返信の取得に失敗しました', vim.log.levels.ERROR)
     end


### PR DESCRIPTION
## 問題の原因

1. `ui/init.lua`の`setup_event_handlers()`関数が呼び出されていなかったため、`thread_selected`イベントのハンドラが登録されていませんでした。
   - `messages.lua`の`M.show_thread()`関数は`thread_selected`イベントを発行していましたが、そのイベントを処理するハンドラが登録されていなかったため、何も起こりませんでした。

2. `init.lua`の`list_thread_replies`関数内で`get_ui().show_thread_replies()`を呼び出していましたが、`ui/init.lua`には`show_thread_replies`関数は定義されておらず、代わりに`show_thread`関数が定義されていました。

## 修正内容

以下の2点を修正しました：

1. `init.lua`の`M.register_event_handlers()`関数内で`get_ui().setup_event_handlers()`を呼び出すように追加
   ```lua
   -- UIのイベントハンドラを登録
   get_ui().setup_event_handlers()