### PR TITLE
スレッド表示時のnilエラーを修正

### DIFF
--- a/lua/neo-slack/api/messages.lua
+++ b/lua/neo-slack/api/messages.lua
@@ -204,8 +204,8 @@ function M.get_thread_replies(channel, thread_ts, callback)
     get_utils().Promise.then_func(promise, function(result)
       vim.schedule(function()
         -- デバッグ情報を追加
-        notify('スレッド返信取得コールバック実行: 返信件数=' .. #result.replies, vim.log.levels.INFO)
-        callback(true, result.replies, result.parent_message)
+        notify('スレッド返信取得コールバック実行: 返信件数=' .. (result.replies and #result.replies or 0), vim.log.levels.INFO)
+        callback(true, result.replies or {}, result.parent_message)
       end)
     end),
     function(err)


### PR DESCRIPTION
## 問題の原因

1. `ui/init.lua`の`setup_event_handlers()`関数が呼び出されていなかったため、`thread_selected`イベントのハンドラが登録されていませんでした。
   - `messages.lua`の`M.show_thread()`関数は`thread_selected`イベントを発行していましたが、そのイベントを処理するハンドラが登録されていなかったため、何も起こりませんでした。

2. `init.lua`の`list_thread_replies`関数内で`get_ui().show_thread_replies()`を呼び出していましたが、`ui/init.lua`には`show_thread_replies`関数は定義されておらず、代わりに`show_thread`関数が定義されていました。

3. スレッド表示時に`result.replies`が`nil`の場合にエラーが発生していました。

## 修正内容

以下の3点を修正しました：

1. `init.lua`の`M.register_event_handlers()`関数内で`get_ui().setup_event_handlers()`を呼び出すように追加
   ```lua
   -- UIのイベントハンドラを登録
   get_ui().setup_event_handlers()